### PR TITLE
Attempt to reintroduce commonmark behavior

### DIFF
--- a/dev/lib/jsx-flow.js
+++ b/dev/lib/jsx-flow.js
@@ -14,6 +14,8 @@
  *   Acorn options.
  * @property {boolean | undefined} addResult
  *   Whether to add `estree` fields to tokens with results from acorn.
+ * @property {boolean} preferInline
+ *   Whether to parse text in flow elements as inline.
  */
 
 import {ok as assert} from 'devlop'
@@ -33,7 +35,9 @@ import {factoryTag} from './factory-tag.js'
  *   Construct.
  */
 export function jsxFlow(acorn, options) {
-  return {name: 'mdxJsxFlowTag', tokenize: tokenizeJsxFlow, concrete: true}
+  const selfConstruct = {name: 'mdxJsxFlowTag', tokenize: tokenizeJsxFlow, concrete: !options.preferInline}
+  
+  return selfConstruct
 
   /**
    * MDX JSX (flow).
@@ -143,27 +147,180 @@ export function jsxFlow(acorn, options) {
      * @type {State}
      */
     function end(code) {
-      // We want to allow expressions directly after tags.
-      // See <https://github.com/micromark/micromark-extension-mdx-expression/blob/d5d92b9/packages/micromark-extension-mdx-expression/dev/lib/syntax.js#L183>
-      // for more info.
-      const leftBraceValue = self.parser.constructs.flow[codes.leftCurlyBrace]
-      /* c8 ignore next 5 -- always a list when normalized. */
-      const constructs = Array.isArray(leftBraceValue)
-        ? leftBraceValue
-        : leftBraceValue
-        ? [leftBraceValue]
-        : []
-      const expression = constructs.find((d) => d.name === 'mdxFlowExpression')
+      if (code === codes.eof) {
+        return ok(code);
+      }
 
-      // Another tag.
-      return code === codes.lessThan
-        ? // We can’t just say: fine. Lines of blocks have to be parsed until an eol/eof.
-          start(code)
-        : code === codes.leftCurlyBrace && expression
-        ? effects.attempt(expression, end, nok)(code)
-        : code === codes.eof || markdownLineEnding(code)
-        ? ok(code)
-        : nok(code)
+      if (!options.preferInline) {
+        // We want to allow expressions directly after tags.
+        // See <https://github.com/micromark/micromark-extension-mdx-expression/blob/d5d92b9/packages/micromark-extension-mdx-expression/dev/lib/syntax.js#L183>
+        // for more info.
+        const leftBraceValue = self.parser.constructs.flow[codes.leftCurlyBrace]
+        /* c8 ignore next 5 -- always a list when normalized. */
+        const constructs = Array.isArray(leftBraceValue)
+          ? leftBraceValue
+          : leftBraceValue
+            ? [leftBraceValue]
+            : []
+        const expression = constructs.find((d) => d.name === 'mdxFlowExpression')
+
+        if (code === codes.lessThan) {
+          // Another tag.
+          // We can’t just say: fine. Lines of blocks have to be parsed until an eol/eof.
+          return start(code);
+        } else if (code === codes.leftCurlyBrace && expression) {
+          return effects.attempt(expression, end, nok)(code);
+        } else if (markdownLineEnding(code)) {
+          return ok(code);
+        } else {
+          return nok(code);
+        }
+      } else {
+        if (markdownLineEnding(code)) {
+          effects.enter(types.lineEnding);
+          effects.consume(code);
+          effects.exit(types.lineEnding);
+          return newlineAfterTag;
+        } else {
+          return maybeText(code);
+        }
+      }
+    }
+
+    /**
+     * Handle content after newline following jsxFlowTag.
+     *
+     * ```markdown
+     * > | <A>\n
+     *          ^
+     * ```
+     *
+     * @type {State} 
+     */
+    function newlineAfterTag(code) {
+      if (markdownSpace(code)) {
+        // handle indent
+        return factorySpace(effects, newlineAfterTag, types.linePrefix)(code);
+      }
+      
+      if (markdownLineEnding(code) || code === codes.eof) {
+        return ok(code);
+      }
+
+      return maybeText(code);
+    }
+
+    /**
+     * Handle something that might be text after jsxFlowTag.
+     *
+     * ```markdown
+     * > | <div>something
+     *          ^
+     * > | <div><span>
+     *          ^
+     * ```
+     *
+     * @type {State}
+     */
+    function maybeText(code) {
+      if (markdownSpace(code)) {
+        // handle indent
+        return factorySpace(effects, maybeText, types.linePrefix)(code);
+      }
+
+      if (code === codes.eof) {
+        return ok(code);
+      }
+
+      if (code === codes.lessThan) {
+        // try next tag, or text
+        return effects.check(selfConstruct, start, textStart)(code);
+      }
+
+      return textStart(code);
+    }
+
+    /**
+     * Handle start of text.
+     *
+     * ```markdown
+     * > | <div>hello
+     *          ^
+     * ```
+     *
+     * @type {State}
+     */
+    function textStart(code) {
+      effects.enter('chunkText', { contentType: 'text' });
+      return textContinuation(code);
+    }
+
+    /**
+     * Handle text after jsxFlowTag.
+     *
+     * ```markdown
+     * > | <div>blah</div>
+     *          ^^^^
+     * ```
+     *
+     * @type {State}
+     */
+    function textContinuation(code) {
+      if (code === codes.lessThan) {
+        // try parse tag
+        return effects.check(
+          selfConstruct,
+          code => {
+            effects.exit('chunkText');
+            return start(code);
+          },
+          code => {
+            effects.consume(code);
+            return textContinuation;
+          }
+        )(code);
+      }
+
+      // </div>something (EOF) is an invalid flow block
+      if (code === codes.eof) {
+        return nok(code);
+      }
+
+      if (markdownLineEnding(code)) {
+        effects.exit('chunkText');
+        effects.enter('lineEnding');
+        effects.consume(code);
+        effects.exit('lineEnding');
+        return textNewlineContinuation;
+      }
+
+      // continue
+      effects.consume(code);
+      return textContinuation;
+    }
+
+    /**
+     * Handle after newline in textContinuation.
+     * 
+     * ```markdown
+     *   | <div>
+     *   |   hello
+     * > |
+     *     ^
+     * ```
+     *   
+     * @type {State}
+     */
+    function textNewlineContinuation(code) {
+      if (markdownSpace(code)) {
+        // handle indent
+        return factorySpace(effects, textNewlineContinuation, types.linePrefix)(code);
+      } else if (markdownLineEnding(code)) {
+        // cannot end block here
+        return nok(code);
+      } else {
+        return maybeText(code);
+      }
     }
   }
 }

--- a/dev/lib/syntax.js
+++ b/dev/lib/syntax.js
@@ -15,6 +15,9 @@
  * @property {boolean | null | undefined} [addResult=false]
  *   Whether to add `estree` fields to tokens with results from acorn
  *   (default: `false`).
+ * @property {boolean | null | undefined} [preferInline=false]
+ *   If true, parse text in JSX flow tags as inline instead of block
+ *   (default: `false`). See CommonMark specification for more details.
  */
 
 import {codes} from 'micromark-util-symbol'
@@ -56,7 +59,8 @@ export function mdxJsx(options) {
     flow: {
       [codes.lessThan]: jsxFlow(acorn || undefined, {
         acornOptions,
-        addResult: settings.addResult || undefined
+        addResult: settings.addResult || undefined,
+        preferInline: settings.preferInline ?? false,
       })
     },
     text: {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/micromark/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/micromark/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/micromark/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Amicromark&type=Issues --> Previous issues on this issue were understandably rejected. I would like to introduce a configuration option for this change.
*   [ ] If applicable, I’ve added docs and tests (**TODO:** I am currently writing tests.)

### Description of changes

This is a proof of concept to reintroduce CommonMark-style HTML blocks to MDX. I would like to request comments on these changes.

Currently, MDX parses
```md
<div class="test">
  content.
</div>
```
as
```html
<div class="test">
  <p>content.</p>
</div>
```
The content within the tags is parsed as a paragraph, but this is often not wanted. CommonMark specifies this behavior to only occur if there is a blank line after the tag, as such:
```md
<div class="test">

content.

</div>
```
but this is needlessly restrictive when you want markdown syntax within flow elements.

This change introduces a configuration option to parse content within flow elements as inline markdown. Paragraph wrapping can be restored by adding a blank line, as in CommonMark.

Examples:

<table>
<thead>
<tr><th>input ===================</th><th>output ===================</th></tr>
</thead
<tbody>
<tr><td>

```md
<div>
  *Hello.*
</div>
```

</td><td>

```html
<div>
  <em>Hello.</em>
</div>
```

</td></tr>
<tr><td>

```md
<div>

*Test*

</div>
```

</td><td>

```html
<div>
  <p>
    <em>Test</em>
  </p>
</div>
```

</td></tr>
<tr><td>

```md
<div>
  Inline
</div> a
```

</td><td>

```html
<p>
  <div>
    Inline
  </div>
  a
</p>
```

</td></tr>

</tbody>
</table>

Configuration is done by setting `preferInline` (bad name, please advise) when creating the extension: `mdxJsx({ acorn, acornOptions, addResult: true, preferInline: true })`. 

I am currently writing tests for this feature and will update the PR when I have good coverage.

I intend to maintain this patch set into the future because I am currently working on a project which wants this feature. I am opening this PR for the primary purpose of gathering feedback. If this feature is not wanted, please close this PR.

Finally, I would like to offer my sincere gratitude for the authors of `micromark` and related packages. Markdown truly is horrible to parse, and `micromark` makes everything so much easier.

### Things that need fixing

~~This does not work because expressions are not handled:~~ fixed hopefully
```md
<div>{'<'}</div>
```

This does not work:
```md
<a>`<`</a>
```
```md
<a>**<Test />**</a>
```

<!--do not edit: pr-->
